### PR TITLE
Conda: use R v4.0

### DIFF
--- a/install_no_docker/conda_pkg/pcgr/meta.yaml
+++ b/install_no_docker/conda_pkg/pcgr/meta.yaml
@@ -90,7 +90,7 @@ requirements:
     # Perl (for VEP)
     - perl-bioperl
     - ensembl-vep ==98.3
-    #- perl-bio-bigfile  # for Loftee (doesn't come with ensemble-vep, but will come with https://github.com/bioconda/bioconda-recipes/pull/18808 once merged)
+    - perl-bio-bigfile  # for Loftee (doesn't come with ensemble-vep, but will come with https://github.com/bioconda/bioconda-recipes/pull/18808 once merged)
     #
     # PCGR: R packages
     - bioconductor-biocinstaller

--- a/install_no_docker/conda_pkg/pcgr/meta.yaml
+++ b/install_no_docker/conda_pkg/pcgr/meta.yaml
@@ -18,16 +18,15 @@ requirements:
   build:
     - curl
     - unzip
-    - r-base
-    - r-devtools
     - tar
     - python =3.7
+    - r-base =4.0.2
     - toml
     #
     # Need R packages build-time to correctly install pcgrr
     - bioconductor-biocinstaller
-    - libgfortran-ng  # to fix -libgfortran error, thanks @pdiakumis
-    - r-purrr >=0.2.4  # to force the one from conda-forge to address this issue https://github.com/jbkunst/highcharter/issues/285
+    - r-devtools
+    - r-purrr
     - r-dplyr
     - r-stringr
     - r-tidyr
@@ -42,24 +41,24 @@ requirements:
     - r-rcpptoml
     - r-ggplot2
     - r-dt
-    - r-stringi >=1.1.7    # for pcgrr
-    - r-htmlwidgets >=1.0  # for DT (by default, 0.9 is getting installed)
+    - r-stringi
+    - r-htmlwidgets
     - r-crosstalk
     - r-deconstructsigs
-    - r-knitr >=1.17
+    - r-knitr
     - r-rmarkdown
     - r-configr           # for pcgrr, -c pcgr
     - r-summarywidget     # for pcgrr, -c pcgr
     - r-rlogging          # for pcgrr, -c pcgr
     - r-collapsibletree   # for CELLector
     - r-sunburstr         # for CELLector, -c pcgr
-    - r-arules            # for CELLector, -c pcgr
+    - r-arules            # for CELLector, on conda-forge now
     - r-biocmanager
     - bioconductor-variantannotation
     - bioconductor-bsgenome.hsapiens.ucsc.hg19
     - bioconductor-bsgenome.hsapiens.ucsc.hg38
     - bioconductor-genomeinfodb
-    - bioconductor-genomicranges  # GenomicRangesS4Vectors
+    - bioconductor-genomicranges
     - bioconductor-regioner
     - bioconductor-mutationalpatterns
     - r-shiny
@@ -68,6 +67,7 @@ requirements:
     #
     # PCGR: python
     - python =3.7
+    - r-base =4.0.2
     - pip
     - numpy
     - cython
@@ -90,15 +90,13 @@ requirements:
     # Perl (for VEP)
     - perl-bioperl
     - ensembl-vep ==98.3
-    - perl-bio-bigfile  # for Loftee (doesn't come with ensemble-vep, but will come with https://github.com/bioconda/bioconda-recipes/pull/18808 once merged)
+    #- perl-bio-bigfile  # for Loftee (doesn't come with ensemble-vep, but will come with https://github.com/bioconda/bioconda-recipes/pull/18808 once merged)
     #
     # PCGR: R packages
-    - r-base
     - bioconductor-biocinstaller
-    - libgfortran-ng  # to fix -libgfortran error, thanks @pdiakumis
-    - r-purrr >=0.2.4  # to force the one from conda-forge to address this issue https://github.com/jbkunst/highcharter/issues/285
-    - r-dplyr
     - r-devtools
+    - r-purrr
+    - r-dplyr
     - r-stringr
     - r-tidyr
     - r-httr
@@ -112,18 +110,18 @@ requirements:
     - r-rcpptoml
     - r-ggplot2
     - r-dt
-    - r-stringi >=1.1.7    # for pcgrr
-    - r-htmlwidgets >=1.0  # for DT (by default, 0.9 is getting installed)
+    - r-stringi
+    - r-htmlwidgets
     - r-crosstalk
     - r-deconstructsigs
-    - r-knitr >=1.17
+    - r-knitr
     - r-rmarkdown
     - r-configr           # for pcgrr, -c pcgr
     - r-summarywidget     # for pcgrr, -c pcgr
     - r-rlogging          # for pcgrr, -c pcgr
     - r-collapsibletree   # for CELLector
     - r-sunburstr         # for CELLector, -c pcgr
-    - r-arules            # for CELLector, -c pcgr
+    - r-arules            # for CELLector
     - r-biocmanager
     - bioconductor-variantannotation
     - bioconductor-bsgenome.hsapiens.ucsc.hg19


### PR DESCRIPTION
Pinning R to 4.0.2 seems to work - package was built with a simple `conda build pcgr`.
Also removed some R pkg pins + `libgfortran-ng` and commented out `perl-bio-bigfile` - that PR mentioned seems to have been merged since a while back.